### PR TITLE
Add support for deprecated annotation

### DIFF
--- a/internal/ingress/annotations/backendprotocol/main.go
+++ b/internal/ingress/annotations/backendprotocol/main.go
@@ -46,20 +46,28 @@ func NewParser(r resolver.Resolver) parser.IngressAnnotation {
 // ParseAnnotations parses the annotations contained in the ingress
 // rule used to indicate the backend protocol.
 func (a backendProtocol) Parse(ing *extensions.Ingress) (interface{}, error) {
+	klog.Infof("Parsing backend protocol annotation")
 	if ing.GetAnnotations() == nil {
 		return HTTP, nil
 	}
 
+	// Proofpoint hack to make v0.24.1 compatible with deprecated "secure-backend" annotation
+	// check backend-protocol first; if it exists, apply it, else check for secure-backends.
+
 	proto, err := parser.GetStringAnnotation("backend-protocol", ing)
-	if err != nil {
-		return HTTP, nil
+	if err == nil {
+		proto = strings.TrimSpace(strings.ToUpper(proto))
+		if !validProtocols.MatchString(proto) {
+			klog.Warningf("Protocol %v is not a valid value for the backend-protocol annotation. Using HTTP as protocol", proto)
+			return HTTP, nil
+		}
+		return proto, nil
 	}
 
-	proto = strings.TrimSpace(strings.ToUpper(proto))
-	if !validProtocols.MatchString(proto) {
-		klog.Warningf("Protocol %v is not a valid value for the backend-protocol annotation. Using HTTP as protocol", proto)
-		return HTTP, nil
+	secure, err := parser.GetBoolAnnotation("secure-backends", ing)
+	if err == nil && secure == true {
+		klog.Infof("Parsing backend protocol annotation: secure-backends is true")
+		return "HTTPS", nil
 	}
-
-	return proto, nil
+	return HTTP, nil
 }


### PR DESCRIPTION
secure-backends is supported now. backend-protocol will be ignored to avoid conflicts.

