### PR TITLE
Cherry-picks from 0.24.1

### DIFF
--- a/rootfs/etc/nginx/lua/certificate.lua
+++ b/rootfs/etc/nginx/lua/certificate.lua
@@ -32,7 +32,7 @@ local function get_pem_cert_key(raw_hostname)
   local hostname = re_sub(raw_hostname, "\\.$", "", "jo")
 
   local pem_cert_key = configuration.get_pem_cert_key(hostname)
-  if pem_cert_key then
+  if pem_cert_key and pem_cert_key ~= '' then
     return pem_cert_key
   end
 


### PR DESCRIPTION
    Merge pull request #2 from nr17/fix-non-tls-ingress	accee0872	nr17 <nr17@users.noreply.github.com>	Jun 17, 2019 at 12:27
    Add support for deprecated annotation	c3be006a7	Nitin Rana <nr17@users.noreply.github.com>	Jun 15, 2019 at 12:51
    fix issues for ingress without tls section	5a0469916	nr17 <nr17@users.noreply.github.com>	Jun 12, 2019 at 22:04

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://git.k8s.io/community/contributors/guide/pull-requests.md#the-pull-request-submit-process and developer guide https://git.k8s.io/community/contributors/devel/development.md#development-guide
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
-->

**What this PR does / why we need it**:

Reinstates the fixes for non-tls ingress and making 0.24.1 compatible with the backend-protocol annotation. 

**Which issue this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close that issue when PR gets merged)*: fixes #

**Special notes for your reviewer**:
